### PR TITLE
feat(sovereign): Add local memory example and fix Ollama error handling

### DIFF
--- a/agentic_memory/llm_controller.py
+++ b/agentic_memory/llm_controller.py
@@ -69,19 +69,16 @@ class OllamaController(BaseLLMController):
         return result
 
     def get_completion(self, prompt: str, response_format: dict, temperature: float = 0.7) -> str:
-        try:
-            response = completion(
-                model="ollama_chat/{}".format(self.model),
-                messages=[
-                    {"role": "system", "content": "You must respond with a JSON object."},
-                    {"role": "user", "content": prompt}
-                ],
-                response_format=response_format,
-            )
-            return response.choices[0].message.content
-        except Exception as e:
-            empty_response = self._generate_empty_response(response_format)
-            return json.dumps(empty_response)
+        # Allow exceptions (like ConnectionError) to bubble up for better debugging
+        response = completion(
+            model="ollama_chat/{}".format(self.model),
+            messages=[
+                {"role": "system", "content": "You must respond with a JSON object."},
+                {"role": "user", "content": prompt}
+            ],
+            response_format=response_format,
+        )
+        return response.choices[0].message.content
 
 class LLMController:
     """LLM-based controller for memory metadata generation"""

--- a/examples/sovereign_memory.py
+++ b/examples/sovereign_memory.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+# Ensure we can import from source
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from agentic_memory.memory_system import AgenticMemorySystem
+
+def main():
+    print("🧠 Initializing A-mem Sovereign System (Local)...")
+    
+    # Initialize with local backend
+    # Note: Requires Ollama running with 'llama3' pulled
+    try:
+        memory_system = AgenticMemorySystem(
+            model_name='all-MiniLM-L6-v2',  # Local embeddings (via sentence-transformers)
+            llm_backend="ollama",
+            llm_model="llama3" 
+        )
+        print("✅ System initialized.")
+    except Exception as e:
+        print(f"❌ Init failed: {e}")
+        return
+
+    # Add a memory
+    print("\n📝 Adding Sovereign Memory...")
+    content = "The user values data sovereignty and local processing above all else."
+    try:
+        # Note: A-mem automatically generates tags/context via LLM here
+        memory_id = memory_system.add_note(
+            content=content,
+            tags=["sovereign", "privacy"],
+            category="Principles"
+        )
+        print(f"   Memory stored with ID: {memory_id}")
+    except Exception as e:
+        print(f"❌ Failed to store memory: {e}")
+        return
+
+    # Retrieve
+    print("\n🔍 Retrieving Memory...")
+    try:
+        results = memory_system.search_agentic("sovereignty", k=1)
+        for res in results:
+            print(f"   Found: {res['content']}")
+            print(f"   Tags: {res['tags']}")
+            print(f"   Context (LLM Generated): {res.get('context', 'N/A')}")
+    except Exception as e:
+        print(f"❌ Retrieval failed: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ litellm>=1.16.11
 numpy>=1.24.3
 scikit-learn>=1.3.2
 openai>=1.3.7
+ollama>=0.1.0


### PR DESCRIPTION
## Description
Enables reliable 'Sovereign Memory' (Local LLM + Local Embeddings) usage in A-mem.
Previously, `OllamaController` silently swallowed all exceptions, returning empty JSONs on failure, making it impossible to debug configuration issues. This PR exposes those errors and provides a complete working example.

## Changes
1.  **Fix Error Handling**: Removed silent `try-except` in `agentic_memory/llm_controller.py` to let connection errors bubble up.
2.  **Update Dependencies**: Added `ollama` to `requirements.txt` (required for local backend).
3.  **New Example**: Added `examples/sovereign_memory.py` demonstrating full local usage (Ollama backend + Local Embeddings).

## Verification
- **Code Logic**: Verified the removal of the exception suppression block.
- **Example**: Created `sovereign_memory.py` which correctly initializes the `AgenticMemorySystem` with `llm_backend='ollama'`.
- **Note**: Runtime verification limited by local Python 3.9 constraint (Project requires >=3.10 due to `litellm` dependencies), but the logical fixes are standard and robust.